### PR TITLE
fix(ios): missing disabling of protection screens in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+* fix(ios): missing disabling of protection screens when calling protectDataLeakage off methods in inactive app state
+
 ## 1.4.0
 
 * feat(ios): add method protectDataLeakageWithColorOff

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -121,7 +121,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/ios/Classes/SwiftScreenProtectorPlugin.swift
+++ b/ios/Classes/SwiftScreenProtectorPlugin.swift
@@ -73,6 +73,7 @@ public class SwiftScreenProtectorPlugin: NSObject, FlutterPlugin {
             break
         case "protectDataLeakageWithBlurOff":
             enabledProtectDataLeakageWithBlur = .off
+            screenProtectorKit?.disableBlurScreen()
             result(true)
             break
         case "protectDataLeakageWithImage":
@@ -92,6 +93,7 @@ public class SwiftScreenProtectorPlugin: NSObject, FlutterPlugin {
             break
         case "protectDataLeakageWithColorOff":
             enabledProtectDataLeakageWithColor = .off
+            screenProtectorKit?.disableColorScreen()
             result(true)
             break
         case "preventScreenshotOn":

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: screen_protector
 description: Safe Data Leakage via Application Background Screenshot and Prevent Screenshot for Android and iOS.
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/prongbang/screen_protector
 
 environment:


### PR DESCRIPTION
Fixes a problem with protection screens being displayed if `protectDataLeakage...` off methods are called when the application is inactive. In this case, when returning to the application, the user will see the protection screen and will not be able to disable it until restarting the application. 