### PR TITLE
commented out unreferenced gitpack url in gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
+        // maven { url 'https://jitpack.io' }
     }
 
     dependencies {
@@ -19,7 +19,7 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
+        // maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
This update attempts to fix an issue where there is an existing package using  gitpack but through a private repo requiring authentication. Since there was no dependency being served over gitpack for this plugin, it made sense to remove the culprit. If there is a cleaner approach to solving this issue from the client app, you can share. Else I think this should be merged 