### PR TITLE
Enforce LTR layout for UIKit text views on RTL apps

### DIFF
--- a/ios/Classes/SwiftScreenProtectorPlugin.swift
+++ b/ios/Classes/SwiftScreenProtectorPlugin.swift
@@ -12,6 +12,12 @@ public class SwiftScreenProtectorPlugin: NSObject, FlutterPlugin {
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         SwiftScreenProtectorPlugin.channel = FlutterMethodChannel(name: "screen_protector", binaryMessenger: registrar.messenger())
+              
+        // Force all UIKit text-based views to use LTR layout direction.
+        UIView.appearance().semanticContentAttribute = .forceLeftToRight
+        UILabel.appearance().semanticContentAttribute = .forceLeftToRight
+        UITextField.appearance().semanticContentAttribute = .forceLeftToRight
+        UITextView.appearance().semanticContentAttribute = .forceLeftToRight
         
         let screenProtectorKitManager = ScreenProtectorKitManager()
         let instance = SwiftScreenProtectorPlugin(screenProtectorKitManager)


### PR DESCRIPTION
Fixed shifted view for ios 26 by adding code to force left-to-right semantic content attribute for UIView, UILabel, UITextField, and UITextView appearances.
 For more info review the following issue on Flutter repo: [https://github.com/flutter/flutter/issues/175523](url)
<img src="https://github.com/user-attachments/assets/95b6f5cd-f289-4f6e-909d-06cc74e57508" width="300">


 
