### PR TITLE
fix(ios): rebuild ScreenProtectorKit when foreground scene changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.8
+
+- Fix iOS crash on iOS 18 when returning from background by recreating the
+  ScreenProtectorKit whenever the active UIWindow changes or a UIScene reconnects.
+
 ## 1.4.7
 
 - Ensured all ScreenProtectorKit initialization runs on the main thread


### PR DESCRIPTION
## Summary
- track the active UIWindow weakly and listen to UIScene lifecycle events
- tear down ScreenProtectorKit when the tracked scene disconnects
- recreate ScreenProtectorKit when a new foreground scene/window becomes key
- guard all calls behind main-thread initialization to keep the manager valid

## Testing
- flutter test
- example/ios: run on iOS 18 simulator, toggle protectDataLeakage modes, minimize/restore app repeatedly → no EXC_BAD_ACCESS