### PR TITLE
fix(spm): Lower iOS deployment target to v13 in Package.swift

### DIFF
--- a/ios/screen_protector/Package.swift
+++ b/ios/screen_protector/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "screen_protector",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v12)
     ],
     products: [
         .library(name: "screen-protector", targets: ["screen_protector"])

--- a/ios/screen_protector/Package.swift
+++ b/ios/screen_protector/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "screen_protector",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v13)
     ],
     products: [
         .library(name: "screen-protector", targets: ["screen_protector"])


### PR DESCRIPTION
### Description
This PR lowers the minimum iOS platform version in `ios/screen_protector/Package.swift` from `.v15` to `.v13`.

### Why is this needed?
- **Avoid build failures**: The current `.v15` restriction causes dependency resolution failures (version mismatch) when integrating this plugin into Flutter apps targeting iOS 13.0 or 14.0 via Swift Package Manager.
- **No iOS 15+ API dependencies**: The plugin's native implementation (`ScreenProtectorPlugin.swift`) does not use any iOS 15+ exclusive APIs. In fact, it already contains backward-compatible checks like `#available(iOS 13.0, *)` and `#available(iOS 11.0, *)`.
- **Underlying support**: The native `ScreenProtectorKit` library itself specifies iOS 12.0 as its minimum version.
- Setting the SPM platform target to `.v13` provides a much better out-of-the-box experience for the majority of Flutter apps using SPM.
